### PR TITLE
[PBD-350] Insight Websockets not working correctly

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -650,8 +650,7 @@ Bitcoin.prototype._zmqTransactionHandler = function(node, message) {
 
     var tx = bitcore.Transaction();
     tx.fromString(message);
-    var txid = bitcore.util.buffer.reverse(hash).toString('hex');
-    self._notifyAddressTxidSubscribers(txid, tx);
+    self._notifyAddressTxidSubscribers(tx.id, tx);
 
   }
 };


### PR DESCRIPTION
1) Seems that when a new transaction comes through, when looking at an address, it takes you to the landing page with a message that says Transaction ID Not found

The tx id is already calculated in bitcore.Transaction so there is no need to recalculate it (Incorrectly)